### PR TITLE
feat: Increase test coverage for src/lib

### DIFF
--- a/tests/unit/errors.test.js
+++ b/tests/unit/errors.test.js
@@ -1,0 +1,396 @@
+import {
+  AppError,
+  ValidationError,
+  NotFoundError,
+  ExternalServiceError,
+  withErrorHandling,
+  createErrorResponse,
+  formatErrorForLogging,
+  safeJsonParse,
+} from '../../src/lib/errors';
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
+
+describe('errors.js', () => {
+  describe('AppError', () => {
+    test('should instantiate with default options', () => {
+      const error = new AppError('Test error');
+      expect(error.message).toBe('Test error');
+      expect(error.status).toBe(500);
+      expect(error.code).toBe('INTERNAL_ERROR'); // Adjusted to actual default
+      expect(error.name).toBe('AppError');
+      expect(error.context).toEqual({});
+    });
+
+    test('should instantiate with custom options', () => {
+      const error = new AppError('Custom error', {
+        status: 400,
+        code: 'BAD_REQUEST',
+        context: { foo: 'bar' },
+      });
+      expect(error.message).toBe('Custom error');
+      expect(error.status).toBe(400);
+      expect(error.code).toBe('BAD_REQUEST');
+      expect(error.name).toBe('AppError');
+      expect(error.context).toEqual({ foo: 'bar' });
+    });
+
+    describe('toResponse()', () => {
+      let originalNodeEnv;
+
+      beforeEach(() => {
+        originalNodeEnv = process.env.NODE_ENV;
+      });
+
+      afterEach(() => {
+        process.env.NODE_ENV = originalNodeEnv;
+      });
+
+      test('should return basic error response structure', () => {
+        const error = new AppError('Test error');
+        const response = error.toResponse();
+        expect(response).toEqual({
+          error: {
+            message: 'Test error',
+            code: 'INTERNAL_ERROR', // Adjusted to actual default
+            context: {}, // Default context is {} and shown in dev
+          },
+        });
+      });
+
+      test('should include context when NODE_ENV is not "production"', () => {
+        process.env.NODE_ENV = 'development';
+        const error = new AppError('Test error', { context: { debug: true } });
+        const response = error.toResponse();
+        expect(response.error.context).toEqual({ debug: true });
+      });
+
+      test('should exclude context when NODE_ENV is "production"', () => {
+        process.env.NODE_ENV = 'production';
+        const error = new AppError('Test error', { context: { debug: true } });
+        const response = error.toResponse();
+        expect(response.error.context).toBeUndefined();
+      });
+
+      // Removed tests for cause in toResponse() context as it's not implemented that way.
+      // Cause is tested in formatErrorForLogging.
+    });
+  });
+
+  describe('Derived Error Classes', () => {
+    describe('ValidationError', () => {
+      test('should instantiate with default status and code', () => {
+        const error = new ValidationError('Validation failed');
+        expect(error.message).toBe('Validation failed');
+        expect(error.status).toBe(400);
+        expect(error.code).toBe('VALIDATION_ERROR');
+        expect(error.name).toBe('ValidationError');
+      });
+
+      test('should pass custom options to AppError', () => {
+        const error = new ValidationError('Custom validation error', {
+          context: { field: 'email' },
+        });
+        expect(error.message).toBe('Custom validation error');
+        expect(error.status).toBe(400);
+        expect(error.code).toBe('VALIDATION_ERROR');
+        expect(error.context).toEqual({ field: 'email' });
+      });
+    });
+
+    describe('NotFoundError', () => {
+      test('should instantiate with default status and code', () => {
+        const error = new NotFoundError('Resource not found');
+        expect(error.message).toBe('Resource not found');
+        expect(error.status).toBe(404);
+        expect(error.code).toBe('NOT_FOUND');
+        expect(error.name).toBe('NotFoundError');
+      });
+
+      test('should pass custom options to AppError', () => {
+        const error = new NotFoundError('Custom not found error', {
+          context: { id: 123 },
+        });
+        expect(error.message).toBe('Custom not found error');
+        expect(error.status).toBe(404);
+        expect(error.code).toBe('NOT_FOUND');
+        expect(error.context).toEqual({ id: 123 });
+      });
+    });
+
+    describe('ExternalServiceError', () => {
+      test('should instantiate with default status and code', () => {
+        const error = new ExternalServiceError('Service unavailable');
+        expect(error.message).toBe('Service unavailable');
+        expect(error.status).toBe(502);
+        expect(error.code).toBe('EXTERNAL_SERVICE_ERROR');
+        expect(error.name).toBe('ExternalServiceError');
+      });
+
+      test('should pass custom options to AppError', () => {
+        const error = new ExternalServiceError('Custom service error', {
+          context: { service: 'payment' },
+        });
+        expect(error.message).toBe('Custom service error');
+        expect(error.status).toBe(502);
+        expect(error.code).toBe('EXTERNAL_SERVICE_ERROR');
+        expect(error.context).toEqual({ service: 'payment' });
+      });
+    });
+  });
+
+  describe('withErrorHandling', () => {
+    const mockLogger = { error: vi.fn() };
+    const originalConsoleError = console.error;
+
+    beforeEach(() => {
+      // Replace console.error with a mock for tests that use it
+      console.error = mockLogger.error;
+      mockLogger.error.mockClear();
+    });
+
+    afterEach(() => {
+      // Restore original console.error
+      console.error = originalConsoleError;
+    });
+
+    test('should return result when wrapped function succeeds', async () => {
+      const syncFn = (a, b) => a + b;
+      const wrappedSyncFn = withErrorHandling(syncFn);
+      // For sync functions that don't return a promise, direct value check is fine.
+      // However, withErrorHandling always returns an async function.
+      await expect(wrappedSyncFn(2, 3)).resolves.toBe(5);
+
+      const asyncFn = async (a, b) => Promise.resolve(a + b);
+      const wrappedAsyncFn = withErrorHandling(asyncFn);
+      await expect(wrappedAsyncFn(2, 3)).resolves.toBe(5);
+    });
+
+    test('should wrap generic Error in AppError with context', async () => {
+      const errorMessage = 'Something went wrong';
+      const syncFn = (a, b) => {
+        throw new Error(errorMessage);
+      };
+      const wrappedSyncFn = withErrorHandling(syncFn);
+
+      try {
+        await wrappedSyncFn(2, 3); // It's an async function now
+        throw new Error('Expected wrappedSyncFn to throw');
+      } catch (e) {
+        expect(e).toBeInstanceOf(AppError);
+        expect(e.message).toBe(errorMessage); // Uses original error message
+        expect(e.cause.message).toBe(errorMessage);
+        expect(e.context.args).toEqual(['2', '3']);
+        // No logger check as withErrorHandling doesn't log itself
+      }
+
+      const asyncFn = async (a, b) => {
+        throw new Error(errorMessage);
+      };
+      const wrappedAsyncFn = withErrorHandling(asyncFn);
+
+      try {
+        await wrappedAsyncFn('foo', 'bar');
+        throw new Error('Expected wrappedAsyncFn to throw');
+      } catch (e) {
+        expect(e).toBeInstanceOf(AppError);
+        expect(e.message).toBe(errorMessage); // Uses original error message
+        expect(e.cause.message).toBe(errorMessage);
+        expect(e.context.args).toEqual(['foo', 'bar']);
+      }
+    });
+
+    test('should re-throw AppError as is', async () => {
+      const appError = new AppError('Custom AppError', { status: 400 });
+      const syncFn = () => {
+        throw appError;
+      };
+      const wrappedSyncFn = withErrorHandling(syncFn);
+
+      try {
+        await wrappedSyncFn(); // It's an async function now
+        throw new Error('Expected wrappedSyncFn to throw');
+      } catch (e) {
+        expect(e).toBe(appError);
+      }
+
+      const asyncFn = async () => {
+        throw appError;
+      };
+      const wrappedAsyncFn = withErrorHandling(asyncFn);
+      try {
+        await wrappedAsyncFn();
+        throw new Error('Expected wrappedAsyncFn to throw');
+      } catch (e) {
+        expect(e).toBe(appError);
+      }
+    });
+  });
+
+  describe('createErrorResponse', () => {
+    test('should create response for AppError', async () => {
+      const error = new AppError('Test AppError', { status: 403, code: 'FORBIDDEN', context: { detail: 'test' } });
+      const response = createErrorResponse(error);
+
+      expect(response).toBeInstanceOf(Response);
+      expect(response.status).toBe(403);
+      expect(response.headers.get('Content-Type')).toBe('application/json');
+
+      const body = await response.json();
+      // In dev, context is included by toResponse()
+      process.env.NODE_ENV = 'development';
+      await expect(createErrorResponse(error).json().then(b => b.error.context)).resolves.toEqual({detail: 'test'});
+
+      // In prod, context is excluded
+      process.env.NODE_ENV = 'production';
+      await expect(createErrorResponse(error).json().then(b => b.error.context)).resolves.toBeUndefined();
+
+      // Restore for other tests
+      process.env.NODE_ENV = 'test';
+      expect(body.error.message).toBe('Test AppError');
+      expect(body.error.code).toBe('FORBIDDEN');
+    });
+
+    test('should create response for generic Error', async () => {
+      const error = new Error('Generic test error');
+      const response = createErrorResponse(error);
+
+      expect(response).toBeInstanceOf(Response);
+      expect(response.status).toBe(500);
+      expect(response.headers.get('Content-Type')).toBe('application/json');
+
+      const body = await response.json();
+      expect(body).toEqual({
+        error: {
+          message: 'An unexpected error occurred', // Default message from createErrorResponse
+          code: 'INTERNAL_ERROR',          // Default code from createErrorResponse
+        },
+      });
+    });
+
+    // This test might be redundant if AppError.toResponse is tested thoroughly
+    // and createErrorResponse correctly uses it.
+    // test('should use custom toResponse if available on AppError', async () => {
+    //   const error = new AppError('Custom toResponse error');
+    //   error.toResponse = vi.fn().mockReturnValue({ customErrorFormat: 'yes' });
+    //   const response = createErrorResponse(error);
+    //   expect(error.toResponse).toHaveBeenCalled();
+    //   const body = await response.json();
+    //   expect(body).toEqual({ customErrorFormat: 'yes' });
+    // });
+  });
+
+  describe('formatErrorForLogging', () => {
+    test('should format generic Error', () => {
+      const error = new Error('Simple error');
+      error.stack = 'Error: Simple error\n    at test (test.js:1:1)';
+      const formatted = formatErrorForLogging(error);
+      expect(formatted).toEqual({
+        name: 'Error',
+        message: 'Simple error',
+        stack: 'Error: Simple error\n    at test (test.js:1:1)',
+      });
+    });
+
+    test('should format AppError with status, code, and context', () => {
+      const error = new AppError('App specific error', {
+        status: 400,
+        code: 'BAD_DATA',
+        context: { userId: 5 },
+      });
+      error.stack = 'AppError: App specific error\n    at test (test.js:1:1)';
+      const formatted = formatErrorForLogging(error);
+      expect(formatted).toEqual({
+        name: 'AppError',
+        message: 'App specific error',
+        stack: 'AppError: App specific error\n    at test (test.js:1:1)',
+        status: 400,
+        code: 'BAD_DATA',
+        context: { userId: 5 },
+      });
+    });
+
+    test('should recursively format error with cause', () => {
+      const rootCause = new Error('Root cause');
+      rootCause.stack = 'Error: Root cause\n    at root (root.js:1:1)';
+      const error = new AppError('Higher level error', { cause: rootCause });
+      error.stack = 'AppError: Higher level error\n    at app (app.js:1:1)';
+
+      const formatted = formatErrorForLogging(error);
+      expect(formatted).toEqual({
+        name: 'AppError',
+        message: 'Higher level error',
+        stack: 'AppError: Higher level error\n    at app (app.js:1:1)',
+        status: 500, // Default AppError status
+        code: 'INTERNAL_ERROR', // Default AppError code
+        context: {}, // Default AppError context
+        cause: {
+          name: 'Error',
+          message: 'Root cause',
+          stack: 'Error: Root cause\n    at root (root.js:1:1)',
+        },
+      });
+    });
+
+     test('should recursively format error with AppError cause', () => {
+      const rootCause = new AppError('Root AppError cause', {status: 400, code: 'BAD_REQUEST', context: {data: 'invalid'}});
+      rootCause.stack = 'AppError: Root AppError cause\n    at root (root.js:1:1)';
+      const error = new AppError('Higher level error', { cause: rootCause, context: {userId: 1} });
+      error.stack = 'AppError: Higher level error\n    at app (app.js:1:1)';
+
+      const formatted = formatErrorForLogging(error);
+      expect(formatted).toEqual({
+        name: 'AppError',
+        message: 'Higher level error',
+        stack: 'AppError: Higher level error\n    at app (app.js:1:1)',
+        status: 500,
+        code: 'INTERNAL_ERROR',
+        context: {userId: 1},
+        cause: {
+          name: 'AppError',
+          message: 'Root AppError cause',
+          stack: 'AppError: Root AppError cause\n    at root (root.js:1:1)',
+          status: 400,
+          code: 'BAD_REQUEST',
+          context: {data: 'invalid'},
+        },
+      });
+    });
+  });
+
+  describe('safeJsonParse', () => {
+    test('should parse valid JSON string', () => {
+      const jsonString = '{"name":"John Doe","age":30}';
+      const result = safeJsonParse(jsonString);
+      expect(result).toEqual({ name: 'John Doe', age: 30 });
+    });
+
+    test('should throw ValidationError for invalid JSON string', () => {
+      const invalidJsonString = '{"name":"John Doe", age:30}'; // Missing quotes around age key
+      try {
+        safeJsonParse(invalidJsonString);
+        throw new Error('safeJsonParse should have thrown an error but did not.');
+      } catch (error) {
+        expect(error).toBeInstanceOf(ValidationError);
+        expect(error.message).toBe('Invalid JSON');
+        expect(error.code).toBe('VALIDATION_ERROR');
+        expect(error.status).toBe(400);
+        expect(error.cause).toBeInstanceOf(Error); // SyntaxError specifically
+      }
+    });
+
+    test('should use custom error message for ValidationError', () => {
+      const invalidJsonString = '{"name":undefined}'; // undefined is not valid JSON
+      const customMessage = 'Failed to parse user data';
+      try {
+        safeJsonParse(invalidJsonString, customMessage);
+        throw new Error('safeJsonParse should have thrown an error but did not.');
+      } catch (error) {
+        expect(error).toBeInstanceOf(ValidationError);
+        expect(error.message).toBe(customMessage);
+        expect(error.code).toBe('VALIDATION_ERROR');
+        expect(error.status).toBe(400);
+        expect(error.cause).toBeInstanceOf(Error);
+      }
+    });
+  });
+});

--- a/tests/unit/logger.test.js
+++ b/tests/unit/logger.test.js
@@ -1,0 +1,237 @@
+import { describe, test, expect, beforeEach, afterEach, vi } from 'vitest';
+import { configure, createScopedLogger, LOG_LEVELS, debug, info, warn, error as logError } from '../../src/lib/logger';
+// Aliased 'error' to 'logError' to avoid conflict with any potential 'error' variables.
+
+// Helper to reset logger configuration to a known state before each test
+const resetLoggerConfig = () => {
+  configure({
+    minLevel: LOG_LEVELS.INFO, // Use numeric log level
+    timestamps: false, // Corrected key: 'timestamps' not 'includeTimestamp'
+    includeContext: true,
+    // Reset any other configurations if they are added in the future
+  });
+};
+
+describe('logger.js', () => {
+  let consoleSpies;
+
+  beforeEach(() => {
+    // Reset logger to default test configuration
+    resetLoggerConfig();
+
+    // Mock console methods
+    consoleSpies = {
+      debug: vi.spyOn(console, 'debug').mockImplementation(() => {}),
+      info: vi.spyOn(console, 'info').mockImplementation(() => {}),
+      warn: vi.spyOn(console, 'warn').mockImplementation(() => {}),
+      error: vi.spyOn(console, 'error').mockImplementation(() => {}),
+    };
+  });
+
+  afterEach(() => {
+    // Restore console mocks
+    consoleSpies.debug.mockRestore();
+    consoleSpies.info.mockRestore();
+    consoleSpies.warn.mockRestore();
+    consoleSpies.error.mockRestore();
+  });
+
+  describe('LOG_LEVELS', () => {
+    test('should have correct numeric values', () => {
+      expect(LOG_LEVELS.DEBUG).toBe(0); // Uppercase
+      expect(LOG_LEVELS.INFO).toBe(1);  // Uppercase
+      expect(LOG_LEVELS.WARN).toBe(2);  // Uppercase
+      expect(LOG_LEVELS.ERROR).toBe(3); // Uppercase
+    });
+  });
+
+  describe('configure', () => {
+    test('should apply default configuration (implicitly tested by resetLoggerConfig)', () => {
+      // resetLoggerConfig applies a known default set for testing
+      info('Test message'); // Use imported 'info' directly
+      expect(consoleSpies.info).toHaveBeenCalledWith(expect.stringContaining('[INFO] Test message'));
+    });
+
+    test('should override default configuration', () => {
+      configure({ minLevel: LOG_LEVELS.DEBUG, timestamps: true, includeContext: false }); // Corrected key, Numeric level
+      debug('Debug message with timestamp'); // Use imported 'debug' directly
+      expect(consoleSpies.debug).toHaveBeenCalledTimes(1);
+      const debugLog = consoleSpies.debug.mock.calls[0][0];
+      expect(debugLog).toContain('[DEBUG] Debug message with timestamp');
+      // Extract timestamp part like "[YYYY-MM-DDTHH:mm:ss.sssZ]"
+      const debugTimestampPart = debugLog.substring(0, debugLog.indexOf(']') + 1);
+      expect(debugTimestampPart).toMatch(/^\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z\]$/);
+
+      info('Info message without context', { test: 'context' }); // Use imported 'info' directly
+      // When includeContext is false, and timestamps is true:
+      expect(consoleSpies.info).toHaveBeenCalledTimes(1);
+      const infoLog = consoleSpies.info.mock.calls[0][0];
+      expect(infoLog).toContain('[INFO] Info message without context');
+      const infoTimestampPart = infoLog.substring(0, infoLog.indexOf(']') + 1);
+      expect(infoTimestampPart).toMatch(/^\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z\]$/);
+      expect(infoLog).not.toContain('{"test":"context"}');
+    });
+
+    test('can reset to default configuration by re-calling configure', () => {
+      configure({ minLevel: LOG_LEVELS.ERROR }); // Numeric level
+      warn('This should not be logged'); // Use imported 'warn' directly
+      expect(consoleSpies.warn).not.toHaveBeenCalled();
+
+      resetLoggerConfig(); // Resets to minLevel: LOG_LEVELS.INFO
+      warn('This should be logged now'); // Use imported 'warn' directly
+      expect(consoleSpies.warn).toHaveBeenCalledWith(expect.stringContaining('[WARN] This should be logged now'));
+    });
+  });
+
+  describe('Logging functions (debug, info, warn, error)', () => {
+    // Test cases now use level name for describe blocks and string formatting,
+    // but numericLevel for configuration and comparison.
+    const testCases = [
+      { levelName: 'debug', numericLevel: LOG_LEVELS.DEBUG, fn: debug, consoleMethod: 'debug' },
+      { levelName: 'info', numericLevel: LOG_LEVELS.INFO, fn: info, consoleMethod: 'info' },
+      { levelName: 'warn', numericLevel: LOG_LEVELS.WARN, fn: warn, consoleMethod: 'warn' },
+      { levelName: 'error', numericLevel: LOG_LEVELS.ERROR, fn: logError, consoleMethod: 'error' },
+    ];
+
+    testCases.forEach(({ levelName, numericLevel, fn, consoleMethod }) => {
+      describe(`${levelName}()`, () => {
+        test(`should log when minLevel is ${levelName} or lower`, () => {
+          configure({ minLevel: numericLevel });
+          fn(`Test ${levelName} message`);
+          expect(consoleSpies[consoleMethod]).toHaveBeenCalledWith(expect.stringContaining(`[${levelName.toUpperCase()}] Test ${levelName} message`));
+        });
+
+        test('should not log when minLevel is higher', () => {
+          const higherLevelValue = numericLevel + 1;
+          // Find a level name for this higher value, if one exists
+          const higherLevelKey = Object.keys(LOG_LEVELS).find(k => LOG_LEVELS[k] === higherLevelValue);
+
+          if (higherLevelKey) { // If a higher level exists
+            configure({ minLevel: higherLevelValue });
+            fn(`Test ${levelName} message`);
+            expect(consoleSpies[consoleMethod]).not.toHaveBeenCalled();
+          } else {
+            // This case means 'numericLevel' is already the highest (error), so it cannot be suppressed by a higher minLevel.
+            // The test for "should log when minLevel is error" covers this.
+            expect(true).toBe(true);
+          }
+        });
+
+        test('should call the correct console method', () => {
+          configure({ minLevel: LOG_LEVELS.DEBUG }); // Ensure all levels are logged
+          fn('Test message');
+          expect(consoleSpies[consoleMethod]).toHaveBeenCalledTimes(1);
+        });
+      });
+    });
+  });
+
+  describe('formatLogMessage (tested via public log functions)', () => {
+    test('should include timestamp when configured', () => {
+      configure({ timestamps: true, minLevel: LOG_LEVELS.INFO }); // Corrected key
+      info('Message with timestamp'); // Use imported 'info'
+      expect(consoleSpies.info).toHaveBeenCalledTimes(1);
+      const logOutput = consoleSpies.info.mock.calls[0][0];
+      expect(logOutput).toContain('[INFO] Message with timestamp');
+      const timestampPart = logOutput.substring(0, logOutput.indexOf(']') + 1);
+      expect(timestampPart).toMatch(/^\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z\]$/);
+    });
+
+    test('should exclude timestamp when configured', () => {
+      configure({ timestamps: false, minLevel: LOG_LEVELS.INFO }); // Corrected key
+      info('Message without timestamp'); // Use imported 'info'
+      expect(consoleSpies.info).toHaveBeenCalledWith('[INFO] Message without timestamp');
+    });
+
+    test('should include context when configured', () => {
+      configure({ includeContext: true, minLevel: LOG_LEVELS.INFO, timestamps: false }); // Explicitly set timestamps: false for stable check
+      info('Message with context', { data: 'value' }); // Use imported 'info'
+      expect(consoleSpies.info).toHaveBeenCalledWith('[INFO] Message with context - {"data":"value"}');
+    });
+
+    test('should exclude context when configured', () => {
+      configure({ includeContext: false, minLevel: LOG_LEVELS.INFO, timestamps: false }); // Explicitly set timestamps: false
+      info('Message without context', { data: 'value' }); // Use imported 'info'
+      expect(consoleSpies.info).toHaveBeenCalledWith('[INFO] Message without context');
+      expect(consoleSpies.info).not.toHaveBeenCalledWith(expect.stringContaining('{"data":"value"}'));
+    });
+
+    test('should handle context serialization errors gracefully', () => {
+      configure({ includeContext: true, minLevel: LOG_LEVELS.INFO, timestamps: false }); // Explicitly set timestamps: false
+      const circularContext = {};
+      circularContext.self = circularContext;
+
+      info('Message with circular context', circularContext); // Use imported 'info'
+      expect(consoleSpies.info).toHaveBeenCalledWith(expect.stringContaining('[INFO] Message with circular context - [Context serialization error]'));
+
+      // Also check console.warn was called for the serialization error itself
+      // This assumes the logger uses its own 'warn' function for this internal warning.
+      // If it directly calls console.warn, this test needs adjustment or clarification on logger's internal behavior.
+      // Based on logger.js, formatLogMessage itself does not log, the main log functions (info, warn etc.) call it.
+      // The logger.js doesn't show an explicit logger.warn for serialization failure, formatLogMessage returns a string.
+      // The test should be that the main log function (e.g. info) still logs *something* for the original message.
+      // The current test for consoleSpies.info for the main message is correct.
+      // Let's verify if the logger.js actually has a fallback to log a warning *about* the serialization.
+      // Reading logger.js: formatLogMessage returns '[Context serialization error]'. It does not call warn itself.
+      // So, the additional expect(consoleSpies.warn) for this case might be incorrect.
+      // Removing it for now as per current understanding of logger.js provided.
+      // If the requirement is that serialization errors *also* produce a separate warning log, logger.js would need to do that.
+    });
+  });
+
+  describe('createScopedLogger', () => {
+    let scopedLogger;
+    const scopeName = 'TestScope';
+
+    beforeEach(() => {
+      // Ensure global logger is set to a low level for these tests
+      // also explicitly set timestamps to false for stable scoped message checks unless testing timestamps
+      configure({ minLevel: LOG_LEVELS.DEBUG, includeContext: true, timestamps: false });
+      scopedLogger = createScopedLogger(scopeName);
+    });
+
+    const scopedTestCases = [
+      { levelName: 'debug', numericLevel: LOG_LEVELS.DEBUG, fnName: 'debug', consoleMethod: 'debug' },
+      { levelName: 'info', numericLevel: LOG_LEVELS.INFO, fnName: 'info', consoleMethod: 'info' },
+      { levelName: 'warn', numericLevel: LOG_LEVELS.WARN, fnName: 'warn', consoleMethod: 'warn' },
+      { levelName: 'error', numericLevel: LOG_LEVELS.ERROR, fnName: 'error', consoleMethod: 'error' },
+    ];
+
+    scopedTestCases.forEach(({ levelName, numericLevel, fnName, consoleMethod }) => {
+      test(`scoped ${fnName}() should log with scope in context`, () => {
+        scopedLogger[fnName](`Scoped ${levelName} message`);
+        expect(consoleSpies[consoleMethod]).toHaveBeenCalledWith(
+          expect.stringContaining(`[${levelName.toUpperCase()}] Scoped ${levelName} message - {"scope":"${scopeName}"}`)
+        );
+      });
+
+      test(`scoped ${fnName}() should merge scope with existing context`, () => {
+        scopedLogger[fnName](`Scoped ${levelName} message with context`, { custom: 'data' });
+        expect(consoleSpies[consoleMethod]).toHaveBeenCalledWith(
+          expect.stringContaining(`[${levelName.toUpperCase()}] Scoped ${levelName} message with context - {"custom":"data","scope":"${scopeName}"}`)
+        );
+      });
+
+      test(`scoped ${fnName}() should respect global minLevel`, () => {
+        configure({ minLevel: LOG_LEVELS.ERROR }); // Numeric level
+        if (numericLevel < LOG_LEVELS.ERROR) {
+          scopedLogger[fnName](`Scoped ${levelName} message`);
+          expect(consoleSpies[consoleMethod]).not.toHaveBeenCalled();
+        } else { // This will only be true for error level
+          scopedLogger[fnName](`Scoped ${levelName} message`);
+          expect(consoleSpies[consoleMethod]).toHaveBeenCalled();
+        }
+      });
+    });
+
+    test('scoped logger should handle context serialization errors gracefully', () => {
+      const circularContext = {};
+      circularContext.self = circularContext;
+
+      scopedLogger.info('Scoped message with circular context', circularContext);
+      // When context serialization fails, the scope is also lost in the output, as JSON.stringify on the merged object fails.
+      expect(consoleSpies.info).toHaveBeenCalledWith(expect.stringContaining(`[INFO] Scoped message with circular context - [Context serialization error]`));
+      // No separate console.warn for serialization error as per logger.js implementation
+    });
+  });
+});


### PR DESCRIPTION
Adds comprehensive unit tests for modules in the src/lib directory that previously had no dedicated test files.

- src/lib/errors.js:
  - Created tests/unit/errors.test.js with 23 tests.
  - Covers AppError, ValidationError, NotFoundError, ExternalServiceError classes.
  - Tests withErrorHandling, createErrorResponse, formatErrorForLogging, and safeJsonParse functions.
  - Ensures correct error properties, response formatting (including NODE_ENV considerations), and error handling logic.

- src/lib/logger.js:
  - Created tests/unit/logger.test.js with 34 tests.
  - Covers LOG_LEVELS, configure function, log formatting (timestamps, context, levels).
  - Tests debug, info, warn, error logging functions, ensuring adherence to minLevel.
  - Verifies createScopedLogger functionality.
  - Mocks console methods to assert correct calls and message formatting.

All new tests pass, and existing tests continue to pass, bringing the total to 65 passing tests.