### PR TITLE
Fix: Resolve multiple failures in integration tests

### DIFF
--- a/vitest.config.js
+++ b/vitest.config.js
@@ -17,6 +17,7 @@ export default defineConfig({
     // To allow mocking of global.fetch, ensure it's not frozen
     setupFiles: ['./tests/setup-vitest.js'], // A setup file if needed for global mocks
   },
+  assetsInclude: ['**/*.html'], // Add this line to treat HTML files as assets
   resolve: {
     // Required for Miniflare to resolve .js files as modules correctly
     mainFields: ['module', 'main'],


### PR DESCRIPTION
This commit addresses several issues that were causing failures in the integration tests for the Cloudflare setup (`tests/integration/worker.test.js`).

The following key fixes were implemented:

1.  Enabled the test suite by removing `.skip()` from the main describe block.
2.  Resolved an HTML parsing error during test runs by adding `assetsInclude: ['**/*.html']` to `vitest.config.js`.
3.  Corrected assertions for error responses. Debugging revealed error objects were structured as `{"error":{"message":"..."}}`, so assertions were updated from `responseBody.message` to `responseBody.error.message`.
4.  Updated test DOIs (e.g., from "10.1/working" to "10.1000/1") to comply with the DOI validation logic, preventing incorrect "newly broken" statuses in `/check-now` and scheduled handler tests.
5.  Addressed timeout issues in tests mocking fetch failures by providing multiple `mockRejectedValueOnce` calls to satisfy the retry logic in `checkDOI`.
6.  Refined assertions for the GET /status endpoint to match the exact response structures for different scenarios (e.g., empty DOI list vs. non-existent DOI list key vs. invalid JSON in list).

All 31 integration tests in `tests/integration/worker.test.js` are now passing.