### PR TITLE
I've made the DOIs in the status table clickable links.

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -182,7 +182,15 @@
                         const tbody = table.createTBody();
                         data.dois.forEach(doiStatus => {
                             const row = tbody.insertRow();
-                            row.insertCell().textContent = doiStatus.doi || 'N/A';
+                            const doiCell = row.insertCell();
+                            if (doiStatus.doi) {
+                                const link = document.createElement('a');
+                                link.href = 'https://doi.org/' + doiStatus.doi;
+                                link.textContent = doiStatus.doi;
+                                doiCell.appendChild(link);
+                            } else {
+                                doiCell.textContent = 'N/A';
+                            }
                             row.insertCell().textContent = doiStatus.lastCheck ? new Date(doiStatus.lastCheck).toLocaleString() : 'N/A';
                             const statusCell = row.insertCell();
                             if (doiStatus.working === true) {


### PR DESCRIPTION
I modified `public/index.html` so that the DOIs listed in the status table are now hyperlinks. Each DOI links to its corresponding page on `https://doi.org/`.

The `fetchStatusAndDisplay` JavaScript function was updated to create an `<a>` element for each DOI, setting its `href` attribute to the appropriate URL and its text content to the DOI itself. If a DOI value is not present, 'N/A' is displayed as before.