### PR TITLE
feat: Add URL scanner to extract and submit DOIs

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -20,6 +20,11 @@
 </head>
 <body>
     <h1>DOI Checker Status</h1>
+    <div id="url-submission-container">
+        <input type="text" id="url-input" placeholder="Enter URL to scan for DOIs">
+        <button id="submit-url-button">Submit URL</button>
+        <div id="submission-feedback"></div> <!-- To display messages to the user -->
+    </div>
     <div id="summary-container">
         <!-- Summary information will be populated here -->
     </div>
@@ -103,6 +108,73 @@
                 summaryContainer.innerHTML = ''; // Clear summary on error too
                 statusContainer.innerHTML = `<p style="color: red;">Error loading status: ${error.message}. See console for details.</p>`;
             });
+
+        // New script logic for URL submission
+        const urlInput = document.getElementById('url-input');
+        const submitUrlButton = document.getElementById('submit-url-button');
+        const submissionFeedback = document.getElementById('submission-feedback');
+
+        submitUrlButton.addEventListener('click', async () => {
+            submissionFeedback.innerHTML = '';
+            const url = urlInput.value.trim();
+
+            if (!url) {
+                submissionFeedback.innerHTML = '<p style="color: red;">Please enter a URL.</p>';
+                return;
+            }
+
+            submissionFeedback.innerHTML = '<p>Processing...</p>';
+
+            try {
+                const response = await fetch(url);
+                if (!response.ok) {
+                    throw new Error(`Failed to fetch URL: ${response.status} ${response.statusText}`);
+                }
+                const htmlText = await response.text();
+
+                const tempDiv = document.createElement('div');
+                tempDiv.innerHTML = htmlText;
+                const links = Array.from(tempDiv.getElementsByTagName('a'));
+                const doiLinks = links.filter(link => link.href && link.href.startsWith('https://doi.org/'));
+
+                if (doiLinks.length === 0) {
+                    submissionFeedback.innerHTML = '<p>No DOI links found on the page.</p>';
+                    return;
+                }
+
+                submissionFeedback.innerHTML = `<p>Found ${doiLinks.length} DOI link(s). Submitting...</p>`;
+                let successfulSubmissions = 0;
+                let failedSubmissions = 0;
+
+                for (const link of doiLinks) {
+                    const doi = link.href.substring('https://doi.org/'.length);
+                    try {
+                        const postResponse = await fetch('/add-doi', {
+                            method: 'POST',
+                            headers: { 'Content-Type': 'application/json' },
+                            body: JSON.stringify({ doi: doi })
+                        });
+                        const result = await postResponse.json();
+                        if (postResponse.ok) {
+                            submissionFeedback.innerHTML += `<p>Successfully submitted DOI: ${doi}</p>`;
+                            successfulSubmissions++;
+                        } else {
+                            submissionFeedback.innerHTML += `<p style="color: red;">Failed to submit DOI: ${doi}. Error: ${result.message || 'Unknown error'}</p>`;
+                            failedSubmissions++;
+                        }
+                    } catch (error) {
+                        submissionFeedback.innerHTML += `<p style="color: red;">Error submitting DOI: ${doi}. ${error.message}</p>`;
+                        failedSubmissions++;
+                    }
+                }
+
+                submissionFeedback.innerHTML += `<p><strong>Submission complete.</strong> Successful: ${successfulSubmissions}, Failed: ${failedSubmissions}.</p>`;
+                // Optionally, refresh the status table
+                // fetchStatus(); // You would need to wrap the status fetching logic in a function
+            } catch (error) {
+                submissionFeedback.innerHTML = `<p style="color: red;">Error processing URL: ${error.message}</p>`;
+            }
+        });
     });
     </script>
 </body>


### PR DESCRIPTION
This commit introduces a new feature to `public/index.html` that allows you to submit a URL.

The key changes include:
- Added a text input field and a 'Submit URL' button to the HTML.
- Implemented JavaScript logic to:
    - Fetch the content of the submitted URL.
    - Parse the fetched HTML to find links starting with `https://doi.org/`.
    - Extract these DOI links.
    - Make individual POST requests to the `/add-doi` API endpoint for each found DOI.
    - Display feedback to you regarding the process and outcomes.

This feature enhances the application by providing a way to add multiple DOIs from a given webpage.