### PR TITLE
feat: Display DOI timestamps in HTML table

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -178,7 +178,7 @@
                         table.classList.add('doi-table');
                         const thead = table.createTHead();
                         const headerRow = thead.insertRow();
-                        const headers = ['DOI', 'Last Check', 'Status', 'HTTP Status', 'Error'];
+                        const headers = ['DOI', 'Last Check', 'Status', 'HTTP Status', 'Error', 'First Checked', 'First Failure', 'First Success'];
                         headers.forEach(text => {
                             const th = document.createElement('th');
                             th.textContent = text;
@@ -210,6 +210,9 @@
                             }
                             row.insertCell().textContent = doiStatus.httpStatus || 'N/A';
                             row.insertCell().textContent = doiStatus.error || 'N/A';
+                            row.insertCell().textContent = doiStatus.firstCheckedTimestamp ? new Date(doiStatus.firstCheckedTimestamp).toLocaleString() : 'N/A';
+                            row.insertCell().textContent = doiStatus.firstFailureTimestamp ? new Date(doiStatus.firstFailureTimestamp).toLocaleString() : 'N/A';
+                            row.insertCell().textContent = doiStatus.firstSuccessTimestamp ? new Date(doiStatus.firstSuccessTimestamp).toLocaleString() : 'N/A';
                         });
                         statusContainer.appendChild(table);
                     } else {


### PR DESCRIPTION
Adds three new columns to the HTML table in `public/index.html`:
- First Checked: Timestamp of when the DOI was first checked.
- First Failure: Timestamp of when a failure was first recorded for the DOI.
- First Success: Timestamp of when a success was first recorded for the DOI.

The JavaScript code in `public/index.html` has been updated to fetch and display these timestamps.